### PR TITLE
feat: Enable suduoers creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,21 @@ Ansible role to create a bunch of users on target hosts
 
 Each user to create has to be defined with an item as follows:
 
-    - name: "johndoe"                (mandatory)
-      gecos: "John Doe,,,"           (default: *omit*)
-      groups: "sudo,adm"             (default: *omit*)
-      ssh_key_create: false          (default: *true*)
-      ssh_key_upload_to_ec2: true    (default: *usermake_ssh_key_upload_to_ec2*)
-      ssh_key_download: true         (default: *usermake_ssh_key_download*)
-      system: false                  (default: *false*)
-      upload_my_key: false           (default: *usermake_upload_ssh_key_to_target*)
-      remove: false                  (default: *omit* or *usermake_remove*)
-      home_dir: "/home/jdoe"         (default: *usermake_home_base_dir/name*)
+```yaml
+usermake_users:
+  - name: "johndoe"                # mandatory
+    gecos: "John Doe,,,"           # default: omit
+    groups: "sudo,adm"             # default: omit
+    passwordless_sudo: true        # default: usermake_sudoer_passwordless
+    ssh_key_create: false          # default: true
+    ssh_key_upload_to_ec2: true    # default: usermake_ssh_key_upload_to_ec2
+    ssh_key_download: true         # default: usermake_ssh_key_download
+    suoder: true                   # default: usermake_sudoer
+    system: false                  # default: false
+    upload_my_key: false           # default: usermake_upload_ssh_key_to_target
+    remove: false                  # default: omit or usermake_remove
+    home_dir: "/home/jdoe"         # default: usermake_home_base_dir/name
+```
 
 Here is the meaning of each varbiable found in the item:
 
@@ -30,16 +35,21 @@ Here is the meaning of each varbiable found in the item:
   to attach to the new user;
 - `groups`: the list of groups the user should belong to. Groups listed
   here are supposed to exist *a priori* (cf. also the [next section](#cannotdo))
-- `remove`: when the item *state* value is *'absent'* whether to remove the user's files when it is deleted,
-  (default
+- `passwordless_sudo`:  when set to `true` the user will be allowed to assume
+  other user identy without typing in any password;
+- `remove`: when the item *state* value is *'absent'* tells whether to
+  remove the files owned by the user when its account is deleted (can be slow);
 - `ssh_key_create`: whether to generate a SSH key pair for the new user;
 - `ssh_key_download`: whether to download the user's generated SSH
   public key to a folder on the local machine (see also the
   `usermake_ssh_key_download_dir` defined below).
 - `ssh_key_upload_to_ec2`: whether to upload the user's generated SSH
   public key to AWS EC2 key management system.
+- `remove`
 - `state`: whether to create ) or delete () the user indicated with the
   values *'present'* or *'absent'* respectively (default: *'present'*);
+- `sudoer`: if set to true the user will gain sudo privileges (see also
+  the `usermake_sudoer` variable);
 - `system`: whether the user should be a system user (w. a low UID
   number and disabled login);
 - `upload_my_key`: whether to upload your local ssh key to the target
@@ -76,24 +86,34 @@ All the variable names used in this role are namespaced with the prefix
 - `usermake_ssh_key_download`: whether to download created users' ssh
   keys locally;
 - `usermake_ssh_key_download_dir`: the directory where to store downloaded
-  public SSH keys (default: *`collected-keys`*);
+  public SSH keys (default: *`{{ playbook_dir }}/collected-keys`*);
 - `usermake_ssh_key_download_dir_mode`: the mode of the directory where
   to store downloaded public SSH keys (default: *0750*);
 - `usermake_ssh_key_passphrase`: the default passphrases to encrypt ssh
   private keys. It is not recommanded to rely on this. You should provide
-  passphrases by other means. (default: *omit* [no passphrase]);
-- `usermake_system`: whether the create users should be system users
+  passphrases by other means. (default: `omit` [no passphrase]);
+- `usermake_sudoer`: whether the created users should be sudoers by
+  default (default: *false*);
+  Note: before granting elevated privileges to any user with this,
+  consider distros provide a sudo package that defines a `sudo` or
+  `sudoers` group that already grants some privileges to its members.
+  The present mecanism is more intended for pre-setting high privilege
+  user on disk images to enable easy setup and provisioning. Not to
+  manage fine grain user or application privileges;
+- `usermake_sudoer_dir`: directory on the target machines in which place
+  the sudoer rule files (default: `/etc/sudoers.d`)
+- `usermake_system`: whether the created users should be system users
   by default (default: *false*);
 - `usermake_upload_ssh_key_to_target`: whether to upload the local user's
   SSH public key to the target host. Useful if you plan to perform tasks
   as that user in the next tasks or roles of your playbook (default: *true*);
 - `usermake_upload_ssh_key_file`: when `usermake_upload_ssh_key_to_target`
   or a user's item `upload_my_key` value is `true`, points to the file where
-  read the public key to upload (default: *~/.ssh/id_rsa.pub*);
+  read the public key to upload (default: `~/.ssh/id_rsa.pub`);
 - `usermake_user_groups`: the groups to assign the created users to by
-  default (default: *omit*);
+  default (default: `omit`);
 - `usermake_users`: the list of users to create, defined with items as
-  described above (default: *[]*);
+  described above (default: `[]`);
 
 
 Dependencies
@@ -107,33 +127,39 @@ Example Playbook
 
 Creating some users:
 
-    - hosts: servers
-      roles:
-         - role: cans.user-make
-           usermake_users:
-             - name: "alice"
-               groups: "sudo,adm"
-               system: "no"
-               ssh_key_create: "yes"
-             - name: "bob"
-               gecos: "Bob no sponge,,,"
-               system: "yes"
-               ssh_key_create: true
+
+```yaml
+- hosts: servers
+  roles:
+     - role: cans.user-make
+       usermake_users:
+         - name: "alice"
+           groups: "sudo,adm"
+           system: "no"
+           ssh_key_create: "yes"
+         - name: "bob"
+           gecos: "Bob no sponge,,,"
+           system: "yes"
+           ssh_key_create: true
+```
 
 Deleting some users:
 
-    - hosts: servers
-      roles:
-        - role: cans.user-make
-          usermake_users:
-            - name: "alice"
-              state: "absent"
-              remove: true  # Remove all users files
-            - name: "bob"
-              state: 
+```yaml
+- hosts: servers
+  roles:
+    - role: cans.user-make
+      usermake_users:
+        - name: "alice"
+          state: "absent"
+          remove: true  # Remove all users files
+        - name: "bob"
+          state: "absent"
+```
 
 You might also want to have a look at the tests found in
-`tests/test.yml` for more usage examples of this role.
+`tests/test.yml` for many more (hopefully exhaustive) usage
+examples of this role.
 
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,12 @@ usermake_ssh_key_download_dir: "collected-keys"  # Ensure this directory exists
 usermake_ssh_key_download_dir_mode: 0700
 usermake_ssh_key_passphrase: "{{omit}}"
 usermake_ssh_key_upload_to_ec2: false
+usermake_sudoer: false
+usermake_sudoer_dir: "/etc/sudoers.d"
+usermake_sudoer_passwordless: false
 usermake_system: false
 usermake_upload_ssh_key_file: "~/.ssh/id_rsa.pub"
 usermake_user_groups: "{{omit}}"
 usermake_users: []
+
+# vim: et:sw=2:syntax=yaml:ts=2:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Ensure {{ usermake_ssh_key_download_dir }} directory exists if needed
+  local_action:
+    module: file
+    path: "{{ usermake_ssh_key_download_dir }}"
+    state: "directory"
+    mode: "{{ usermake_ssh_key_download_dir_mode }}"
+  when: 'usermake_ssh_key_download or usermake_users|default([])|selectattr("ssh_key_download")'
+  run_once: true
+
 - name: Create User(s)
   user:
     home: "{{item.home_dir|default(usermake_home_base_dir + '/' + item.name)}}"
@@ -26,13 +35,13 @@
   when: item.state | default('present') == 'present'
   with_items: "{{ usermake_users }}"
 
-- name: Ensure {{ usermake_ssh_key_download_dir }} directory exists if needed
-  local_action:
-    module: file
-    path: "{{ usermake_ssh_key_download_dir }}"
-    state: "directory"
-    mode: "{{ usermake_ssh_key_download_dir_mode }}"
-  when: usermake_ssh_key_download or usermake_users|default([])|selectattr("ssh_key_download")
+- name: Give sudoer privileges to the user
+  template:
+    src: "sudoers/privileged"
+    dest: "{{ usermake_sudoer_dir }}/{{ item.name }}"
+    mode: "0400"
+  when: 'item.sudoer | default(usermake_sudoer)'
+  with_items: "{{ usermake_users }}"
 
 - name: Save Users public keys to local folder
   local_action:

--- a/templates/sudoers/privileged
+++ b/templates/sudoers/privileged
@@ -1,0 +1,3 @@
+# Generated with Ansible -- DO NOT EDIT
+# User rules for {{ item.name }}
+{{ item.name }} ALL=(ALL) {% if item.passwordless_sudo | default(usermake_sudoer_passwordless) %}NOPASSWD:{% endif %}ALL

--- a/tests/local.yml
+++ b/tests/local.yml
@@ -9,6 +9,7 @@
         image: "python:3.6-stretch"
         groups:
           - servers
+
   roles:
     - role: chrismeyersfsu.provision_docker
       provision_docker_inventory: "{{inventory}}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,64 +1,24 @@
 ---
 - hosts: servers
   remote_user: root
-  vars:
-    ssh_key_download_dir: "~/collected-keys"
-    first_user_group:
-      - name: "alpha"
-        gecos: "Alpha,,,"
-        groups: "sudo,adm"
-        system: false
-        # The two values below are inconsistent: we ask to download a
-        # public key that will not be generated. We do not want the
-        # role to fail because of that.
-        ssh_key_create: false
-        ssh_key_download: true
-      - name: "bravo"
-        gecos: "Bravo,,,"
-        system: false
-        ssh_key_create: true
-        ssh_key_download: true
-      - name: "charlie"
-        gecos: "Charlie,,,"
-        groups: "sudo,adm"
-        system: true  # Create a system user
-        ssh_key_create: false
-      - name: "delta"
-        gecos: "Delta,,,"
-        groups: "sudo,adm"
-        # system: false  # Left unspecified on purpose, default is false
-        ssh_key_create: true
-    second_user_group:
-      - name: "foxtrot"
-        gecos: "Foxtrot,,,"
-        groups: "sudo,adm"
-        system: true
-        ssh_key_create: true
-      - name: "golf"
-        gecos: "Golf,,,"
-        groups: "sudo,adm"
-        system: false
-        ssh_key_create: false
+  vars_files:
+    - vars/all.yml
 
   pre_tasks:
-    - name: Create SSH key collection directory
-      local_action:
-        module: file
-        dest: "{{ ssh_key_download_dir }}"
-        state: "directory"
-        mode: 0750
+    # Only required if target host does not have sudo installed.
+    - name: Create fake sudoers directory
+      file:
+        dest: "{{ usermake_sudoer_dir }}"
+        state: directory
 
   roles:
     - role: user-make
       usermake_ssh_key_download: false
-      usermake_ssh_key_download_dir: "{{ ssh_key_download_dir }}"
       usermake_users: "{{ first_user_group }}"
 
     - role: user-make
       # We want make sure `usermake_ssh_key_download` works
       usermake_ssh_key_download: true
-      # We want to make sure the role can create the
-      usermake_ssh_key_download_dir: "{{ ssh_key_download_dir + '2'}}"
       usermake_users: "{{ second_user_group }}"
 
   tasks:
@@ -95,7 +55,7 @@
     - name: "Ensure Bravo's public key was downloaded"
       local_action:
         module: stat
-        path: "{{ ssh_key_download_dir + '/bravo@' + ansible_hostname + '.pub' }}"
+        path: "{{ usermake_ssh_key_download_dir + '/bravo@' + ansible_hostname + '.pub' }}"
       register: bravoscollectedkey
       failed_when: bravoscollectedkey.stat.islnk is not defined
 
@@ -133,7 +93,7 @@
     - name: "Ensure Foxtrot's public key was downloaded (it should have been)"
       local_action:
         module: stat
-        path: "{{ ssh_key_download_dir + '2/foxtrot@' + ansible_hostname + '.pub' }}"
+        path: "{{ usermake_ssh_key_download_dir + '/foxtrot@' + ansible_hostname + '.pub' }}"
       register: foxtrotcollectedkey
       failed_when: foxtrotcollectedkey.stat.islnk is not defined
 
@@ -141,53 +101,37 @@
     - name: "Golf's public key was downloaded (it should not have been)"
       local_action:
         module: stat
-        path: "{{ ssh_key_download_dir + '2/golf@' + ansible_hostname + '.pub' }}"
+        path: "{{ usermake_ssh_key_download_dir + '/golf@' + ansible_hostname + '.pub' }}"
       register: golfcollectedkey
       failed_when: golfcollectedkey.stat.islnk is defined
+
+    # Checking on Hotel
+    - name: "Hotel should have a sudoer file"
+      stat:
+        path: "{{ usermake_sudoer_dir }}/hotel"
+      become: true
+      register: hotelsudoerfile
+      failed_when: not hotelsudoerfile|success
+
+    # Checking on India
+    - name: "Hotel should have a sudoer file"
+      lineinfile:
+        path: "{{ usermake_sudoer_dir }}/india"
+        regexp: ".*NOPASSWD:.*"
+        line: "india ALL=(ALL) NOPASSWD:ALL"
+      check_mode: yes
+      become: true
+      register: indiasudoerfile
+      failed_when: not indiasudoerfile|success or indiasudoerfile|changed
+
 
 ##
 #  This second play is just to clean-up the target host
 ##
 - hosts: servers
   remote_user: root
-  vars:
-    usermake_ssh_key_download_dir: "~/collected-keys"
-    first_user_group:
-      - name: "alpha"
-        gecos: "Alpha,,,"
-        groups: "sudo,adm"
-        system: false
-        # The two values below are inconsistent: we ask to download a
-        # public key that will not be generated. We do not want the
-        # role to fail because of that.
-        ssh_key_create: false
-        ssh_key_download: true
-      - name: "bravo"
-        gecos: "Bravo,,,"
-        system: false
-        ssh_key_create: true
-        ssh_key_download: true
-      - name: "charlie"
-        gecos: "Charlie,,,"
-        groups: "sudo,adm"
-        system: true  # Create a system user
-        ssh_key_create: false
-      - name: "delta"
-        gecos: "Delta,,,"
-        groups: "sudo,adm"
-        # system: false  # Left unspecified on purpose, default is false
-        ssh_key_create: true
-    second_user_group:
-      - name: "foxtrot"
-        gecos: "Foxtrot,,,"
-        groups: "sudo,adm"
-        system: true
-        ssh_key_create: true
-      - name: "golf"
-        gecos: "Golf,,,"
-        groups: "sudo,adm"
-        system: false
-        ssh_key_create: false
+  vars_files:
+    - vars/all.yml
 
   pre_tasks:
     # First group with explicit remove value
@@ -222,10 +166,8 @@
     - name: "Clean-up downloaded keys directory"
       local_action:
         module: file
-        path: "{{ item }}"
+        path: "{{ usermake_ssh_key_download_dir }}"
         state: absent
-      with_items:
-        - "{{usermake_ssh_key_download_dir}}/"
-        - "{{usermake_ssh_key_download_dir}}2/"
+
 
 # vim: syntax=yaml:et:ts=2:sw=4:

--- a/tests/vars/all.yml
+++ b/tests/vars/all.yml
@@ -1,0 +1,50 @@
+---
+# Override to not write in random or read-only places
+usermake_ssh_key_download_dir: "{{ playbook_dir }}/collected-keys"
+usermake_sudoer_dir: "{{ playbook_dir }}/sudoers.d"
+# The users we will create to test the role.
+first_user_group:
+  - name: "alpha"
+    gecos: "Alpha,,,"
+    groups: "sudo,adm"
+    system: false
+    # The two values below are inconsistent: we ask to download a
+    # public key that will not be generated. We do not want the
+    # role to fail because of that.
+    ssh_key_create: false
+    ssh_key_download: true
+  - name: "bravo"
+    gecos: "Bravo,,,"
+    system: false
+    ssh_key_create: true
+    ssh_key_download: true
+  - name: "charlie"
+    gecos: "Charlie,,,"
+    groups: "sudo,adm"
+    system: true  # Create a system user
+    ssh_key_create: false
+  - name: "delta"
+    gecos: "Delta,,,"
+    groups: "sudo,adm"
+    # system: false  # Left unspecified on purpose, default is false
+    ssh_key_create: true
+second_user_group:
+  - name: "foxtrot"
+    gecos: "Foxtrot,,,"
+    groups: "sudo,adm"
+    system: true
+    ssh_key_create: true
+  - name: "golf"
+    gecos: "Golf,,,"
+    groups: "sudo,adm"
+    system: false
+    ssh_key_create: false
+  - name: "hotel"
+    system: false
+    sudoer: true
+  - name: "india"
+    system: false
+    sudoer: true
+    passwordless_sudo: true
+
+


### PR DESCRIPTION
- Adds the means to create sudoers users.
- Fixes a bug where the directory to collect created user's SSH key
  would be placed in a directory under `~/` instead of `tests/`.