### PR TITLE
fix: Don't upload ssh key when not asked to.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,0 +1,56 @@
+Change Log
+==========
+
+This log tracks all notable changes made to the ``cans.user-make`` role
+for Ansible.
+
+The format is based on `Keep a Changelog <http://keepachangelog.com/en/1.0.0/>`_
+and this project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
+
+
+Unreleased
+----------
+
+Added:
+~~~~~~
+
+* Added
+
+
+Changed:
+~~~~~~~~
+
+* Changed
+
+Fixed:
+~~~~~~
+
+* Fixed
+
+
+Version v1.1.1 -- 2018-02-17
+----------------------------
+
+Fixed:
+~~~~~~
+
+* Role would always try to upload the local user's key to the newly
+  created remote user account, even if asked not to;
+
+
+Version v1.1.0 -- 2018-02-16
+----------------------------
+
+Added:
+~~~~~~
+
+* Ability to create sudo users;
+
+
+Version v1.0.0 -- 2017-02-16
+----------------------------
+
+Added:
+~~~~~~
+
+* initial release, includes basic functionalities;

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ You might also want to have a look at the tests found in
 examples of this role.
 
 
+Todo
+----
+
+Implement integration testing for AWS key upload.
+
+
 License
 -------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ usermake_sudoer: false
 usermake_sudoer_dir: "/etc/sudoers.d"
 usermake_sudoer_passwordless: false
 usermake_system: false
+usermake_upload_ssh_key_to_target: true
 usermake_upload_ssh_key_file: "~/.ssh/id_rsa.pub"
 usermake_user_groups: "{{omit}}"
 usermake_users: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,9 +30,9 @@
   authorized_key:
     user: "{{ item.name }}"
     state: "present"
-    key: "{{ lookup('file', my_ssh_public_key | default('~/.ssh/id_rsa.pub')) }}"
+    key: "{{ lookup('file', usermake_upload_ssh_key_file|expanduser) }}"
   become: yes
-  when: item.state | default('present') == 'present'
+  when: item.state | default('present') == 'present' and item.upload_my_key | default(usermake_upload_ssh_key_to_target)
   with_items: "{{ usermake_users }}"
 
 - name: Give sudoer privileges to the user

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -1,6 +1,29 @@
 Running the tests
 =================
 
+
+Specificities of this role
+--------------------------
+
+
+This role requires that the local user (YOU!) has a SSH public key
+available somewhere as, part of this role features, is its ability
+to upload that key to the newly created user's account.
+
+By default it looks for a key in `~/.ssh/id_rsa.pub`. You can
+either specify another key location using the role's
+``usermake_upload_ssh_key_file`` variable::
+
+    $ ansible-playbook tests/local.yml --extra-vars "usermake_upload_ssh_key_file=<some other location>"
+
+Or skip the related tests altogether using the `key-upload` tag::
+
+    $ ansible-playbook tests/local.yml --skip-tags key-upload
+
+
+Setup your test environment
+---------------------------
+
 If you want to run the tests locally, you will need to:
 
 

--- a/tests/key-upload.yml
+++ b/tests/key-upload.yml
@@ -1,0 +1,35 @@
+---
+- hosts: servers
+  name: "Local user key upload test suite"
+  remote_user: root
+  vars_files:
+    - vars/all.yml
+
+  roles:
+    - role: user-make
+      usermake_ssh_key_download: false
+      usermake_upload_ssh_key_to_target: false
+      # Ensures we fail if any attempt to read the file is made.
+      usermake_upload_ssh_key_file: "/some/fantasy/path/to/make/sure/we/fail/if/the/file/is/read"
+      usermake_users: "{{ third_user_group }}"
+    - role: user-make
+      usermake_ssh_key_download: false
+      usermake_upload_ssh_key_to_target: false
+      usermake_users: "{{ forth_user_group }}"
+
+  tasks:
+    - name: "Kilo should have not have an authorized_keys file"
+      stat:
+        path: "{{ '~kilo'| expanduser + '/.ssh/authorized_keys' }}"
+      register: kilo_authorizedkeys_file
+      failed_when: not kilo_authorizedkeys_file|success or kilo_authorizedkeys_file.stat.exists
+
+    - name: "Lima should have an authorized_keys file"
+      lineinfile:
+        path: "{{ '~lima' | expanduser + '/.ssh/authorized_keys' }}"
+        regexp: "^ssh-rsa.*"
+        line: "{{ lookup('file', usermake_upload_ssh_key_file | expanduser) }}"
+      check_mode: yes
+      become: true
+      register: lima_authorizedkeys_file
+      failed_when: not lima_authorizedkeys_file|success or lima_authorizedkeys_file|changed

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: servers
+  name: "Basic user creation function checks"
   remote_user: root
   vars_files:
     - vars/all.yml
@@ -114,7 +115,7 @@
       failed_when: not hotelsudoerfile|success
 
     # Checking on India
-    - name: "Hotel should have a sudoer file"
+    - name: "India should have a sudoer file"
       lineinfile:
         path: "{{ usermake_sudoer_dir }}/india"
         regexp: ".*NOPASSWD:.*"
@@ -125,10 +126,17 @@
       failed_when: not indiasudoerfile|success or indiasudoerfile|changed
 
 
+- import_playbook: "key-upload.yml"
+  tags:
+    - all
+    - key-upload
+
+
 ##
 #  This second play is just to clean-up the target host
 ##
 - hosts: servers
+  name: "Clean-up"
   remote_user: root
   vars_files:
     - vars/all.yml

--- a/tests/vars/all.yml
+++ b/tests/vars/all.yml
@@ -47,4 +47,19 @@ second_user_group:
     sudoer: true
     passwordless_sudo: true
 
+third_user_group:
+  - name: "juliett"
+    system: false
+    sudoer: false
+    upload_my_key: false
+
+forth_user_group:
+  - name: "kilo"
+    system: false
+    sudoer: false
+    upload_my_key: false
+  - name: "lima"
+    system: false
+    sudoer: false
+    upload_my_key: true
 


### PR DESCRIPTION
- Fix the issue where the local user's public key would *always* be
  uploaded to the new created remote user account(s);
- Add test coverage for part of the roles related to the above issue;
- Updated documentation (about how to run the tests, mostly);