### PR TITLE
fix(tasks): Some local tasks were not protected against user delegation.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -20,12 +20,20 @@ Added:
 Changed:
 ~~~~~~~~
 
-* Changed
+Fixed:
+~~~~~~
+
+* Fixed 
+
+
+Version v1.1.2 -- 2018-02-20
+----------------------------
 
 Fixed:
 ~~~~~~
 
-* Fixed
+* Role when used with user delegation would also delegate local tasks
+  to that user (issue #6)
 
 
 Version v1.1.1 -- 2018-02-17
@@ -35,7 +43,7 @@ Fixed:
 ~~~~~~
 
 * Role would always try to upload the local user's key to the newly
-  created remote user account, even if asked not to;
+  created remote user account, even if asked not to (issue #4);
 
 
 Version v1.1.0 -- 2018-02-16

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,9 @@
     path: "{{ usermake_ssh_key_download_dir }}"
     state: "directory"
     mode: "{{ usermake_ssh_key_download_dir_mode }}"
-  when: 'usermake_ssh_key_download or usermake_users|default([])|selectattr("ssh_key_download")'
+  when: "usermake_ssh_key_download or usermake_users|default([])|selectattr('ssh_key_download', 'defined')|list|length > 0"
   run_once: true
+  become: false  # This local action should never be delegate to another user
 
 - name: Create User(s)
   user:
@@ -50,6 +51,7 @@
     dest: "{{ usermake_ssh_key_download_dir + '/' + item.item.name + '@' + ansible_hostname + '.pub' }}"
   when: item.state | default('present') == 'present' and item.item.ssh_key_create | default(usermake_ssh_key_create) and item.item.ssh_key_download | default(usermake_ssh_key_download)
   with_items: "{{ private_usermake_users_facts.results }}"
+  become: false  # This local action should never be delegate to another user
 
 - name: Upload Users public key to AWS as EC2 key
   local_action:

--- a/tests/key-download.yml
+++ b/tests/key-download.yml
@@ -1,0 +1,73 @@
+---
+- hosts: servers
+  name: "Remote user key download test suite"
+  remote_user: root
+  vars_files:
+    - vars/all.yml
+
+  roles:
+    - role: user-make
+      usermake_ssh_key_download: false
+      usermake_upload_ssh_key_to_target: false
+      usermake_users: "{{ fifth_user_group }}"
+
+  tasks:
+    - name: "Mike should have is key downloaded"
+      local_action:
+        module: stat
+        path: "{{ usermake_ssh_key_download_dir }}/mike@{{ ansible_hostname }}.pub"
+      register: mike_local_key_file
+      failed_when: not mike_local_key_file|success or not mike_local_key_file.stat.exists
+
+    - name: "November should not have his key downloaded"
+      local_action:
+        module: stat
+        path: "{{ usermake_ssh_key_download_dir }}/november@{{ ansible_hostname }}.pub"
+      register: november_local_key_file
+      failed_when: not november_local_key_file|success or november_local_key_file.stat.exists
+
+    - name: "Clean up local SSH key directory"
+      local_action:
+        module: file
+        path: "{{ usermake_ssh_key_download_dir }}"
+        state: absent
+
+
+- hosts: servers
+  name: "Remote user key download test suite when role called with user delegation (regression tests for issue #6)"
+  # `remote_user` does not seemed to be honored when using docker
+  # See e.g. https://github.com/ansible/ansible/issues/13388
+  remote_user: admin
+  vars_files:
+    - vars/all.yml
+
+  roles:
+    - role: user-make
+      usermake_ssh_key_download: false
+      usermake_upload_ssh_key_to_target: false
+      usermake_users: "{{ fifth_user_group }}"
+      become: true
+
+  tasks:
+    - name: "Mike should have had his key downloaded"
+      local_action:
+        module: stat
+        path: "{{ usermake_ssh_key_download_dir }}/mike@{{ ansible_hostname }}.pub"
+      register: mike_local_key_file
+      failed_when: not mike_local_key_file|success or not mike_local_key_file.stat.exists
+
+    - name: "November should not have had his key downloaded"
+      local_action:
+        module: stat
+        path: "{{ usermake_ssh_key_download_dir }}/november@{{ ansible_hostname }}.pub"
+      register: november_local_key_file
+      failed_when: not november_local_key_file|success or november_local_key_file.stat.exists
+
+    - name:
+      local_action:
+        module: file
+        path: "{{ usermake_ssh_key_download_dir }}"
+        state: absent
+
+
+# vim: et:sw=2:syntax=yaml:ts=2:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -31,6 +31,7 @@
         key: alpha
       register: alphas_entity
       failed_when: alphas_entity.ansible_facts.getent_passwd['alpha'][1] | int < 1000
+
     - name: "Check Alpha's SSH key was *not* generated"
       stat:
         path: /home/alpha/.ssh/id_rsa
@@ -130,6 +131,12 @@
   tags:
     - all
     - key-upload
+
+
+- import_playbook: "key-download.yml"
+  tags:
+    - all
+    - key-download
 
 
 ##

--- a/tests/vars/all.yml
+++ b/tests/vars/all.yml
@@ -1,6 +1,8 @@
 ---
 # Override to not write in random or read-only places
 usermake_ssh_key_download_dir: "{{ playbook_dir }}/collected-keys"
+# Override `usermake_sudoer_dir' because on many CI systems `/etc/sudoers.d'
+# is not writeable.
 usermake_sudoer_dir: "{{ playbook_dir }}/sudoers.d"
 # The users we will create to test the role.
 first_user_group:
@@ -62,4 +64,18 @@ forth_user_group:
     system: false
     sudoer: false
     upload_my_key: true
+
+fifth_user_group:
+  - name: "mike"
+    ssh_key_download: true
+    ssh_key_create: true
+    sudoer: false
+    system: false
+    upload_my_key: false
+  - name: "november"
+    ssh_key_create: true
+    ssh_key_download: false
+    sudoer: false
+    system: false
+    upload_my_key: false
 


### PR DESCRIPTION
This is a fix for issue #6.

- Enforce `become: force` for local actions;
- Fixes incorrect `when:` statement that was always true;
- Add tests (including regression tests for this particular issue);