### PR TITLE
Remove deprecated filters.

### DIFF
--- a/tests/key-download.yml
+++ b/tests/key-download.yml
@@ -17,14 +17,14 @@
         module: stat
         path: "{{ usermake_ssh_key_download_dir }}/mike@{{ ansible_hostname }}.pub"
       register: mike_local_key_file
-      failed_when: not mike_local_key_file|success or not mike_local_key_file.stat.exists
+      failed_when: mike_local_key_file is not success or not mike_local_key_file.stat.exists
 
     - name: "November should not have his key downloaded"
       local_action:
         module: stat
         path: "{{ usermake_ssh_key_download_dir }}/november@{{ ansible_hostname }}.pub"
       register: november_local_key_file
-      failed_when: not november_local_key_file|success or november_local_key_file.stat.exists
+      failed_when: november_local_key_file is not success or november_local_key_file.stat.exists
 
     - name: "Clean up local SSH key directory"
       local_action:
@@ -54,14 +54,14 @@
         module: stat
         path: "{{ usermake_ssh_key_download_dir }}/mike@{{ ansible_hostname }}.pub"
       register: mike_local_key_file
-      failed_when: not mike_local_key_file|success or not mike_local_key_file.stat.exists
+      failed_when: mike_local_key_file is not success or not mike_local_key_file.stat.exists
 
     - name: "November should not have had his key downloaded"
       local_action:
         module: stat
         path: "{{ usermake_ssh_key_download_dir }}/november@{{ ansible_hostname }}.pub"
       register: november_local_key_file
-      failed_when: not november_local_key_file|success or november_local_key_file.stat.exists
+      failed_when: november_local_key_file is not success or november_local_key_file.stat.exists
 
     - name:
       local_action:

--- a/tests/key-upload.yml
+++ b/tests/key-upload.yml
@@ -25,7 +25,7 @@
       stat:
         path: "{{ '~kilo'| expanduser + '/.ssh/authorized_keys' }}"
       register: kilo_authorizedkeys_file
-      failed_when: not kilo_authorizedkeys_file|success or kilo_authorizedkeys_file.stat.exists
+      failed_when: kilo_authorizedkeys_file is not success or kilo_authorizedkeys_file.stat.exists
 
     - name: "Lima should have an authorized_keys file"
       lineinfile:
@@ -35,4 +35,4 @@
       check_mode: yes
       become: true
       register: lima_authorizedkeys_file
-      failed_when: not lima_authorizedkeys_file|success or lima_authorizedkeys_file|changed
+      failed_when: lima_authorizedkeys_file is not success or lima_authorizedkeys_file is changed

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -113,7 +113,7 @@
         path: "{{ usermake_sudoer_dir }}/hotel"
       become: true
       register: hotelsudoerfile
-      failed_when: not hotelsudoerfile|success
+      failed_when: hotelsudoerfile is not success
 
     # Checking on India
     - name: "India should have a sudoer file"
@@ -124,7 +124,7 @@
       check_mode: yes
       become: true
       register: indiasudoerfile
-      failed_when: not indiasudoerfile|success or indiasudoerfile|changed
+      failed_when: indiasudoerfile is not success or indiasudoerfile is changed
 
 
 - import_playbook: "key-upload.yml"


### PR DESCRIPTION
Removes all usages of the `|success`, `|changed` and
`|failed` filters deprecated since [Ansible 2.4][1]

Closes #11.
[1]: https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.4.html#tests